### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This MCP server provides tools for uploading images and videos to Cloudinary through Claude Desktop and compatible MCP clients.
 
+<a href="https://glama.ai/mcp/servers/zjiw1ry8ly"><img width="380" height="200" src="https://glama.ai/mcp/servers/zjiw1ry8ly/badge" alt="Cloudinary Server MCP server" /></a>
+
 ## Setup Instructions
 
 1. First, ensure you have a Cloudinary account and get your credentials from the [Cloudinary Console](https://console.cloudinary.com/settings/api-keys):


### PR DESCRIPTION
This PR adds a badge for the [Cloudinary MCP Server](https://glama.ai/mcp/servers/zjiw1ry8ly) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/zjiw1ry8ly"><img width="380" height="200" src="https://glama.ai/mcp/servers/zjiw1ry8ly/badge" alt="Cloudinary Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.