### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18-alpine AS builder
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package.json package-lock.json ./
+
+# Install any needed dependencies for the build
+RUN npm install
+
+# Copy the rest of the application code to the working directory
+COPY src ./src
+COPY tsconfig.json ./
+
+# Build the application
+RUN npm run build
+
+# Use a smaller base image for the final release
+FROM node:18-alpine
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy built files and package.json to the final image
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./package.json
+
+# Install only production dependencies
+RUN npm install --production
+
+# Environment variables for Cloudinary configuration
+ENV CLOUDINARY_CLOUD_NAME=your_cloud_name
+ENV CLOUDINARY_API_KEY=your_api_key
+ENV CLOUDINARY_API_SECRET=your_api_secret
+
+# Set the command to run the application
+ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # Cloudinary MCP Server
+[![smithery badge](https://smithery.ai/badge/@felores/cloudinary-mcp-server)](https://smithery.ai/server/@felores/cloudinary-mcp-server)
 
 This MCP server provides tools for uploading images and videos to Cloudinary through Claude Desktop and compatible MCP clients.
 
 <a href="https://glama.ai/mcp/servers/zjiw1ry8ly"><img width="380" height="200" src="https://glama.ai/mcp/servers/zjiw1ry8ly/badge" alt="Cloudinary Server MCP server" /></a>
 
 ## Installation
+
+### Installing via Smithery
+
+To install Cloudinary Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@felores/cloudinary-mcp-server):
+
+```bash
+npx -y @smithery/cli install @felores/cloudinary-mcp-server --client claude
+```
 
 ### Quick Install (Recommended)
 ```bash

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,25 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - cloudinaryCloudName
+      - cloudinaryApiKey
+      - cloudinaryApiSecret
+    properties:
+      cloudinaryCloudName:
+        type: string
+        description: The Cloudinary cloud name.
+      cloudinaryApiKey:
+        type: string
+        description: The Cloudinary API key.
+      cloudinaryApiSecret:
+        type: string
+        description: The Cloudinary API secret.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: ['dist/index.js'], env: { CLOUDINARY_CLOUD_NAME: config.cloudinaryCloudName, CLOUDINARY_API_KEY: config.cloudinaryApiKey, CLOUDINARY_API_SECRET: config.cloudinaryApiSecret } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai?utm_campaign=pr) to render configurations for the end-user. It also allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@felores/cloudinary-mcp-server?utm_campaign=pr&modal=claim), claiming it and clicking "Deploy".
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. Note that the installation only works after the server is deployed.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂